### PR TITLE
Keys that are not defined inside a specific environment are also exporte...

### DIFF
--- a/capistrano-figaro-yml.gemspec
+++ b/capistrano-figaro-yml.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'capistrano', '~> 3.1'
   gem.add_runtime_dependency 'sshkit', '~> 1.2', '>= 1.2.0'
 
-  gem.add_development_dependency 'rake', '~> 0'
+  gem.add_development_dependency 'rake', '>= 0'
 end

--- a/lib/capistrano/figaro_yml/helpers.rb
+++ b/lib/capistrano/figaro_yml/helpers.rb
@@ -6,7 +6,15 @@ module Capistrano
 
       def local_figaro_yml(env)
         @local_figaro_yml ||= YAML.load_file(figaro_yml_local_path)
-        @local_figaro_yml[env]
+        local_figaro = {}
+
+        @local_figaro_yml.each do |key, value|
+          if key == env or !value.is_a?(Hash)
+            local_figaro[key] = @local_figaro_yml[key]
+          end
+        end
+
+        local_figaro
       end
 
       def figaro_yml_env
@@ -14,7 +22,7 @@ module Capistrano
       end
 
       def figaro_yml_content
-        { figaro_yml_env => local_figaro_yml(figaro_yml_env) }.to_yaml
+        local_figaro_yml(figaro_yml_env).to_yaml
       end
 
       # error helpers


### PR DESCRIPTION
The application.yml can have some key global to every environment which are then defined on the root level, example:

```
mandrill_api_key: key_value

beta:
  database_password: password_value

production:
  database_password: password_value
```

In that case the mandrill_api_key is common to every environment. It should also be exported while doing `cap beta setup`.

I added a small modification to make this possible.

Now, a `cap beta setup` will upload

```
mandrill_api_key: key_value
beta:
  database_password: password_value
```

instead of

```
beta:
  database_password: password_value
```

Thanks for you helpful gem.
