### PR TITLE
Deploy application.yml using rails_env as the key

### DIFF
--- a/lib/capistrano/figaro_yml/helpers.rb
+++ b/lib/capistrano/figaro_yml/helpers.rb
@@ -7,10 +7,11 @@ module Capistrano
       def local_figaro_yml(env)
         @local_figaro_yml ||= YAML.load_file(figaro_yml_local_path)
         local_figaro = {}
+        deployment_env = fetch(:rails_env, env)
 
         @local_figaro_yml.each do |key, value|
           if key == env or !value.is_a?(Hash)
-            local_figaro[key] = @local_figaro_yml[key]
+            local_figaro[deployment_env] = @local_figaro_yml[key]
           end
         end
 


### PR DESCRIPTION
Since figaro only looks for a set of environment variables in the application.yml with a key corresponding to the application rails environment, if rails_env differs from figaro_yml_env, rails_env should be the key used in the deployed application.yml.

This is useful in the scenario where multiple capistrano stages share the same rails_env, but have different environment variables in the local application.yml.

i.e. with a local application.yml corresponding to two capistrano stages:

```
staging_v1:
  SOME_KEY: 'some value'
  RAILS_ENV: 'staging'
staging_v2:
  SOME_KEY: 'some other value'
  RAILS_ENV: 'staging'
```

If I do `cap staging_v1 setup` it should deploy the following, otherwise figaro will not pick it up.

```
staging:
  SOME_KEY: 'some value'
  RAILS_ENV: 'staging'
```
