### PR TITLE
deployment_env should be a string

### DIFF
--- a/lib/capistrano/figaro_yml/helpers.rb
+++ b/lib/capistrano/figaro_yml/helpers.rb
@@ -7,7 +7,7 @@ module Capistrano
       def local_figaro_yml(env)
         @local_figaro_yml ||= YAML.load_file(figaro_yml_local_path)
         local_figaro = {}
-        deployment_env = fetch(:rails_env, env)
+        deployment_env = fetch(:rails_env, env).to_s
 
         @local_figaro_yml.each do |key, value|
           if key == env


### PR DESCRIPTION
Now it's a symbol. Unfortunately fiagaro not support symbols as env key.

result file was:

```

---
:dev:
  KEY: val
```

Now:

```

---
dev:
  KEY: val
```
