### PR TITLE
Ruby 3.2 compatibility

### DIFF
--- a/lib/capistrano/tasks/figaro_yml.rake
+++ b/lib/capistrano/tasks/figaro_yml.rake
@@ -11,7 +11,7 @@ end
 namespace :figaro_yml do
 
   task :check_figaro_file_exists do
-    next if File.exists?(figaro_yml_local_path)
+    next if File.exist?(figaro_yml_local_path)
     check_figaro_file_exists_error
     exit 1
   end


### PR DESCRIPTION
`File.exists?` does not exist in Ruby 3.2, but the alias `File.exist?` does.

https://stackoverflow.com/questions/14351272/why-do-i-get-undefined-method-exist-for-fileclass